### PR TITLE
Missing chattr command from docker uninstall

### DIFF
--- a/content/install-with-other/docker/standalone/_index.md
+++ b/content/install-with-other/docker/standalone/_index.md
@@ -78,6 +78,7 @@ grep -q '/opt/pwx/oci /opt/pwx/oci' /proc/self/mountinfo && sudo umount /opt/pwx
 sudo rm -fr /opt/pwx
 
 # 4: [OPTIONAL] Remove configuration files. Doing this means UNRECOVERABLE DATA LOSS.
+sudo chattr -ie /etc/pwx/.private.json
 sudo rm -fr /etc/pwx
 ```
 


### PR DESCRIPTION
Signed-off-by: Kent Munson <kent@Kents-MacBook-Pro.local>