### PR TITLE
Update resize-pvc.md

### DIFF
--- a/content/portworx-install-with-kubernetes/storage-operations/create-pvcs/resize-pvc.md
+++ b/content/portworx-install-with-kubernetes/storage-operations/create-pvcs/resize-pvc.md
@@ -12,7 +12,7 @@ This document describes how to dynamically resize a volume (PVC) using Kubernete
 ## Pre-requisites
 
 * Resize support for PVC is in Kubernetes 1.11 and above. If you have an older version, use [pxctl volume update](/reference/cli/updating-volumes) to update the volume size.
-* The StorageClass must have `allowVolumeExpansion: true`.
+* The StorageClass must have `allowVolumeExpansion: "true"`.
 * The PVC must be in use by a Pod.
 
 ## Example


### PR DESCRIPTION
If you try to create a storageclass like this:

```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
    name: px-ha-sc-minio
provisioner: kubernetes.io/portworx-volume
parameters:
   repl: "3"
   allowVolumeExpansion: true
   io_profile: "sequential"
   io_priority: "high"
   group: "minio"
```

Then you will get an error like:
`Error from server (BadRequest): error when creating "px-ha-sc.yml": StorageClass in version "v1" cannot be handled as a StorageClass: v1.StorageClass.Parameters: ReadString: expects " or n, but found t, error found in #10 byte of ...|pansion":true,"group|..., bigger context ...|-sc-minio"},"parameters":{"allowVolumeExpansion":true,"group":"minio","io_priority":"high","io_profi|...`

The values in the parameters section must be encapsulated in quotes, like this:

```
apiVersion: storage.k8s.io/v1
metadata:
    name: px-ha-sc-minio
provisioner: kubernetes.io/portworx-volume
parameters:
   repl: "3"
   allowVolumeExpansion: "true"
   io_profile: "sequential"
   io_priority: "high"
   group: "minio"
```