### PR TITLE
Add a section for Vault Namespaces.

### DIFF
--- a/content/key-management/vault/_index.md
+++ b/content/key-management/vault/_index.md
@@ -65,6 +65,9 @@ Portworx requires the following Vault credentials to use its APIs
 
     Name of the Kubernetes Auth Role created in vault for Portworx. This field is set only when using Kubernetes Auth Method.
 
+- **Vault Namespace [VAULT_NAMESPACE]**
+
+    This option allows you to set a global vault namespace for the Portworx cluster. All vault requests by PX will use this vault namespace if an override is not provided. 
 
 
 ## Kubernetes users
@@ -100,6 +103,7 @@ data:
   VAULT_CLIENT_CERT: <base64 encoded file path where the Client Certificate is present on all the nodes>
   VAULT_CLIENT_KEY: <base64 encoded file path where the Client Key is present on all the nodes>
   VAULT_TLS_SERVER_NAME: <base64 encoded value of the TLS server name>
+  VAULT_NAMESPACE: <base64 encoded value of the global vault namespace for portworx>
 ```
 
 Portworx will look for this secret with name `px-vault` under the `portworx` namespace. While installing Portworx it creates a kubernetes role binding which grants access to reading kubernetes secrets only from the `portworx` namespace.
@@ -188,6 +192,7 @@ data:
   VAULT_TLS_SERVER_NAME: <base64 encoded value of the TLS server name>
   VAULT_AUTH_METHOD: a3ViZXJuZXRlcw== // base64 encoded value of "kubernetes"
   VAULT_AUTH_KUBERNETES_ROLE: cG9ydHdvcng= // base64 encoded value of the kubernetes auth role "portworx"
+  VAULT_NAMESPACE: <base64 encoded value of the global vault namespace for portworx>
 ```
 
 {{<info>}}
@@ -288,6 +293,9 @@ Provide the following Vault credentials (key value pairs) as environment variabl
 - [Optional] VAULT_CLIENT_KEY=<file path where the Client Key is present on all the nodes>
 - [Optional] VAULT_TLS_SERVER_NAME=<TLS server name>
 
+{{<info>}}
+**NOTE:** Providing VAULT_NAMESPACE as environment variable is not supported. Please specify the vault namespace through pxctl commands as shown in subsequent sections.
+{{</info>}}
 
 ### Step 2: Set up Vault as the secrets provider for Portworx.
 

--- a/content/key-management/vault/pvc-enc/_index.md
+++ b/content/key-management/vault/pvc-enc/_index.md
@@ -41,7 +41,9 @@ In this method, each PVC can be encrypted with its own secret key.
 
 {{% content "shared/key-management-other-providers-pvc-encryption.md" %}}
 
-__Important: Make sure secret `your-secret-key` exists in Vault__
+{{<info>}}
+**IMPORTANT:** Make sure secret `your-secret-key` exists in Vault.
+{{</info>}}
 
 ### Encryption using PVC annotations with Vault Namespaces
 
@@ -74,4 +76,6 @@ The PVC requires an extra annotation `px/vault-namespace` to indicate the Vault 
 set in Portworx using the parameter `VAULT_NAMESPACE`, you don't need to specify this annotation. However if the key resides in any other namespace then this annotation is
 required.
 
-__Important: Make sure secret `your-secret-key` exists in the namespace `your-vault-namespace` in Vault__
+{{<info>}}
+**IMPORTANT:** Make sure the secret `your-secret-key` exists in the namespace `your-vault-namespace` in Vault.
+{{</info>}}

--- a/content/key-management/vault/pvc-enc/_index.md
+++ b/content/key-management/vault/pvc-enc/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Encrypting Kubernetes PVCs with Vault
 weight: 1
-keywords: Vault Key Management, Hashicorp, encrypt PVC, Kubernetes, k8s
+keywords: Vault Key Management, Hashicorp, encrypt PVC, Kubernetes, k8s, Vault Namespaces
 description: Instructions on using Vault with Portworx for encrypting PVCs in Kubernetes
 noicon: true
 series: vault-secret-uses
@@ -11,7 +11,7 @@ hidden: true
 
 {{% content "shared/key-management-intro.md" %}}
 
-There are two ways in which Portworx volumes can be encrypted and are dependent on how a secret passphrase is provided to Portworx.
+There are two ways in which Portworx volumes can be encrypted and are dependent on how the Vault secret key is provided to Portworx.
 
 ### Encryption using Storage Class
 
@@ -20,6 +20,12 @@ In this method, Portworx will use the cluster wide secret key to encrypt PVCs.
 #### Step 1: Set a cluster wide secret
 
 {{% content "shared/key-management-set-cluster-wide-secret.md" %}}
+
+If you are using Vault Namespaces use the following command to set the cluster-wide secret key in a specific vault namespace:
+
+```text
+pxctl secrets set-cluster-key --secret_options=vault-namespace=<name of vault-namespace>
+```
 
 {{% content "shared/key-management-storage-class-encryption.md" %}}
 
@@ -31,8 +37,42 @@ In this method, each PVC can be encrypted with its own secret key.
 
 {{% content "shared/key-management-enc-storage-class-spec.md" %}}
 
-#### Step 2: Create a PVC with annotation
+#### Step 2: Create a PVC with annotations
 
 {{% content "shared/key-management-other-providers-pvc-encryption.md" %}}
 
-__Important: Make sure secret `your_secret_key` exists in Vault__
+__Important: Make sure secret `your-secret-key` exists in Vault__
+
+### Encryption using PVC annotations with Vault Namespaces
+
+When you have **Vault Namespaces** enabled and your secret resides inside a specific namespace, then the name of that namespace and the secret key needs
+to be provided to Portworx.
+
+#### Step 1: Create a Storage Class
+
+{{% content "shared/key-management-enc-storage-class-spec.md" %}}
+
+#### Step 2: Create a PVC with annotations
+
+```text
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: secure-mysql-pvc
+  annotations:
+    px/secret-name: <your-secret-key>
+    px/vault-namespace: <your-vault-namesapce>
+spec:
+  storageClassName: portworx-sc
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+```
+
+The PVC requires an extra annotation `px/vault-namespace` to indicate the Vault namespace where the secret key resides. If your key resides in the global vault namespace
+set in Portworx using the parameter `VAULT_NAMESPACE`, you don't need to specify this annotation. However if the key resides in any other namespace then this annotation is
+required.
+
+__Important: Make sure secret `your-secret-key` exists in the namespace `your-vault-namespace` in Vault__

--- a/content/key-management/vault/pvc-enc/_index.md
+++ b/content/key-management/vault/pvc-enc/_index.md
@@ -45,8 +45,7 @@ __Important: Make sure secret `your-secret-key` exists in Vault__
 
 ### Encryption using PVC annotations with Vault Namespaces
 
-When you have **Vault Namespaces** enabled and your secret resides inside a specific namespace, then the name of that namespace and the secret key needs
-to be provided to Portworx.
+If you have **Vault Namespaces** enabled and your secret resides inside a specific namespace, you must provide the name of that namespace and the secret key to Portworx.
 
 #### Step 1: Create a Storage Class
 

--- a/content/key-management/vault/vol-enc/_index.md
+++ b/content/key-management/vault/vol-enc/_index.md
@@ -46,6 +46,18 @@ You can use one of the following methods to encrypt Portworx volumes with Google
     Encrypted Shared volume successfully created: 77957787758406722
     ```
 
+    If you are using Vault Namespaces, and your secret key `key1` resides in a namespace called `ns1` then use the following command to create
+    an encrypted volume
+
+
+    ```text
+    pxctl volume create --secure --secret_key key1 --secret_options=vault-namespace=ns1 enc_vol
+    ```
+
+    ```output
+    Encrypted volume successfully created: 374663852714325215
+    ```
+
     **Docker users:**
 
     Use the following command to create an encrypted volume named `enc_vol`:
@@ -111,12 +123,13 @@ You can use one of the following methods to encrypt Portworx volumes with Google
 
 ## Encrypt volumes using a cluster-wide secret
 
-Set the default cluster-wide secret, and specify the secret name as `default`. Portworx will use the cluster-wide secret as a passphrase to encrypt your volume.
+A cluster wide secret key is a common key that can be used to encrypt all your volumes. This common key needs to be pre-created in Vault.
+Portworx will use this cluster-wide secret as a passphrase to encrypt your volume.
 
-1. Set the cluster-wide secret key. Enter the following `pxctl secrets set-cluster-key` command specifying the `--secret` parameter with your secret passphrase (this example uses `mysecretpassphrase`):
+1. Set the cluster-wide secret key. Enter the following `pxctl secrets set-cluster-key` command specifying the `--secret` parameter with the secret name you created in Vault (this example uses `mysecret`):
 
     ```text
-    pxctl secrets set-cluster-key --secret mysecretpassphrase
+    pxctl secrets set-cluster-key --secret mysecret
     ```
 
     ```output
@@ -126,7 +139,12 @@ Set the default cluster-wide secret, and specify the secret name as `default`. P
 **WARNING:** You must set the cluster-wide secret only once. If you overwrite the cluster-wide secret, the volumes encrypted with the old secret will become unusable.
     {{</info>}}
 
-    If you've specified your cluster wide secret key in the `config.json` file, the `pxctl secrets set-cluster-key` command will overwrite it. Even if you restart your cluster, Portworx will use the key you passed as an argument to the `pxctl secrets set-cluster-key` command.
+    
+    If you are using Vault Namespaces use the following command to set the cluster-wide secret key in a specific vault namespace (this example uses `ns1` as the vault namespace)
+
+    ```text
+    pxctl secrets set-cluster-key --secret_options=vault-namespace=ns1 --secret mysecret
+    ```
 
 2. Create a new encrypted volume. Enter the `pxctl volume create` command, specifying the following arguments:
   * `--secure`

--- a/content/shared/key-management-per-volume-secret.md
+++ b/content/shared/key-management-per-volume-secret.md
@@ -20,11 +20,11 @@ Encrypted volume successfully created: 374663852714325215
 To create a **shared encrypted** volume run the following command:
 
 ```text
-pxctl volume create --shared --secret_key key1 --secure --size 10 enc_shared_vol
+pxctl volume create --sharedv4 --secret_key key1 --secure --size 10 enc_shared_vol
 ```
 
 ```output
-Encrypted Shared volume successfully created: 77957787758406722
+Encrypted Sharedv4 volume successfully created: 77957787758406722
 ```
 
 To create an **encrypted** volume using a specific secret through docker, run the following command:

--- a/content/shared/key-management-set-cluster-wide-secret.md
+++ b/content/shared/key-management-set-cluster-wide-secret.md
@@ -5,7 +5,8 @@ description: Shared content for all Kubernetes secret docs - set cluster-wide se
 hidden: true
 ---
 
-A cluster wide secret key is a common key that can be used to encrypt all your volumes. You can set the cluster secret key using the following command.
+A cluster wide secret key is a common key that can be used to encrypt all your volumes. This common key needs to be pre-created in your KMS provider.
+You can set the cluster secret key using the following command.
 
 ```text
 pxctl secrets set-cluster-key
@@ -16,4 +17,4 @@ Enter cluster wide secret key: *****
 Successfully set cluster secret key!
 ```
 
-This command needs to be run just once for the cluster. If you have added the cluster secret key through the config.json, the above command will overwrite it. Even on subsequent Portworx restarts, the cluster secret key in config.json will be ignored for the one set through the CLI.
+In the above prompt you need to enter the secret key that you created in your KMS. This command needs to be run just once for the cluster. 


### PR DESCRIPTION
- Vault namespaces can only be used with Kubernetes and with per volume secrets.