### PR TITLE
PD-643: Add support for 2.6 Intree Multitenancy Support

### DIFF
--- a/content/cloud-references/security/kubernetes/shared-secret-model-multitenancy/storageclass.md
+++ b/content/cloud-references/security/kubernetes/shared-secret-model-multitenancy/storageclass.md
@@ -4,6 +4,27 @@ keywords: storageclass, csi, security, authorization
 weight: 40
 ---
 
+# StorageClass for non-CSI
+
+The following StorageClass enables your tenants to create volumes
+using their token stored in a secret in their namespace.
+
+```text
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: multitenant
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "1"
+  openstorage.io/auth-secret-name: px-k8s-user
+  openstorage.io/auth-secret-namespace: ${pvc.namespace}
+```
+
+Note the value `${pvc.namespace}`. This will ensure that the Portworx
+provisioner gets the appropriate token which is tied to the namespace
+of the PVC.
+
 # StorageClass for CSI
 
 The following CSI StorageClass enables your tenants to create volumes

--- a/content/portworx-install-with-kubernetes/operate-and-maintain-on-kubernetes/authorization/_index.md
+++ b/content/portworx-install-with-kubernetes/operate-and-maintain-on-kubernetes/authorization/_index.md
@@ -7,7 +7,12 @@ series: k8s-op-maintain
 keywords: authorization, security, kubernetes, k8s
 ---
 
-This section describes how to enable and manage Portworx authorization in
+This is a reference section describing how to manage Portworx authorization in
 Kubernetes
+
+{{<info>}}
+For a step by step setup of guide of how to enable Portworx authorization, please see
+[Securing your Portworx system](/cloud-references/security/).
+{{</info>}}
 
 {{<homelist series="k8s-op-maintain-auth">}}

--- a/content/portworx-install-with-kubernetes/operate-and-maintain-on-kubernetes/authorization/_index.md
+++ b/content/portworx-install-with-kubernetes/operate-and-maintain-on-kubernetes/authorization/_index.md
@@ -11,7 +11,7 @@ This is a reference section describing how to manage Portworx authorization in
 Kubernetes
 
 {{<info>}}
-For a step by step setup of guide of how to enable Portworx authorization, please see
+**NOTE:** For a step-by-step setup guide showing how to enable Portworx authorization, please refer to 
 [Securing your Portworx system](/cloud-references/security/).
 {{</info>}}
 

--- a/content/portworx-install-with-kubernetes/operate-and-maintain-on-kubernetes/authorization/enable.md
+++ b/content/portworx-install-with-kubernetes/operate-and-maintain-on-kubernetes/authorization/enable.md
@@ -6,7 +6,12 @@ weight: 100
 series: k8s-op-maintain-auth
 ---
 
-Before proceeding with this installation, please review the [Security](/concepts/authorization) model used by Portworx.
+Before proceeding with this document, please review the [Security](/concepts/authorization) model used by Portworx.
+
+{{<info>}}
+For a step by step setup of guide of how to enable Portworx authorization, please see
+[Securing your Portworx system](/cloud-references/security/).
+{{</info>}}
 
 ## Enabling authorization
 {{<info>}}

--- a/content/portworx-install-with-kubernetes/operate-and-maintain-on-kubernetes/authorization/manage.md
+++ b/content/portworx-install-with-kubernetes/operate-and-maintain-on-kubernetes/authorization/manage.md
@@ -7,46 +7,11 @@ series: k8s-op-maintain-auth
 ---
 
 ## Creating volumes
-Portwox authorization provides a method of protection for creating volumes through Kubernetes. Users must provide a token when requesting volumes in order to create a private volume. These tokens must be saved in a Secret, normally in the same namespace as the PVC.
+Portwox authorization provides a method of protection for creating volumes
+through Kubernetes. PVCs must refer to a StorageClass which point to the
+Kubernetes Secret containing the token for the user.
 
-The key in the Secret which holds the token must be named `auth-token`.
-
-Then the annotations of the PVC can be used to point to the secret holding the
-token. The following table shows the annotation keys used to point to the
-secret:
-
-| Name | Description |
-| ---- | ----------- |
-| `openstorage.io/auth-secret-name` | Name of the secret which has the token |
-| `openstorage.io/auth-secret-namespace` | Optional key which contains the namespace of the secret reference by `auth-secret-name`. If omitted, the namespace of the PVC will be used as default |
-
-Here is an example:
-
-* Create a secret with the token:
-
-```text
-kubectl create secret generic px-secret \
-  -n default --from-literal=auth-token=ey..hs
-```
-
-* Create a PVC request for a 2Gi volume with the appropriate authorization:
-
-```text
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: pvc-auth
-  annotations:
-    volume.beta.kubernetes.io/storage-class: portworx-sc
-    openstorage.io/auth-secret-name: px-secret
-    openstorage.io/auth-secret-namespace: default
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 2Gi
-```
+For more information please see [Securing your Portworx system](/cloud-references/security/).
 
 ## Stork
 When using CRDs consumed by Stork, you must use the same authorization model

--- a/content/portworx-install-with-kubernetes/operate-and-maintain-on-kubernetes/authorization/manage.md
+++ b/content/portworx-install-with-kubernetes/operate-and-maintain-on-kubernetes/authorization/manage.md
@@ -11,7 +11,7 @@ Portwox authorization provides a method of protection for creating volumes
 through Kubernetes. PVCs must refer to a StorageClass which point to the
 Kubernetes Secret containing the token for the user.
 
-For more information please see [Securing your Portworx system](/cloud-references/security/).
+For more information, refer to the [Securing your Portworx system](/cloud-references/security/) article of the Portworx documentation.
 
 ## Stork
 When using CRDs consumed by Stork, you must use the same authorization model

--- a/content/reference/Developer SDK/_index.md
+++ b/content/reference/Developer SDK/_index.md
@@ -24,6 +24,6 @@ The following table shows the OpenStorage SDK version released in each version o
 | v1.6.x, v1.7.x | [v0.9.x](https://libopenstorage.github.io/w/reference.html) |
 | 2.0.x | [v0.22.x](https://libopenstorage.github.io/w/reference.html) |
 | 2.1.x, 2.2.x, 2.3.x, 2.4.x | [v0.42.x](https://libopenstorage.github.io/w/reference.html) |
-| 2.5.x | [v0.42.24](https://libopenstorage.github.io/w/reference.html) |
+| 2.5.x | [v0.42.24+](https://libopenstorage.github.io/w/reference.html) |
 
 You may need to match the version of the OpenStorage SDK Client version.


### PR DESCRIPTION
Due to a major security issue found in https://portworx.atlassian.net/browse/PWX-8385 we needed to immediately stop supporting the ability to set the secret information in the PVC, since the user can point to any secret. Instead, the solution was based on CSI and have the StorageClass point to the secret. The StorageClass is managed by the administrator.

PD: https://portworx.atlassian.net/browse/PD-643

